### PR TITLE
rope edit suggestions update

### DIFF
--- a/RopeParison.Data/Migrations/20240206094359_Mig10.Designer.cs
+++ b/RopeParison.Data/Migrations/20240206094359_Mig10.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using RopeParison.Data;
 
@@ -11,9 +12,11 @@ using RopeParison.Data;
 namespace RopeParison.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20240206094359_Mig10")]
+    partial class Mig10
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/RopeParison.Data/Migrations/20240206094359_Mig10.cs
+++ b/RopeParison.Data/Migrations/20240206094359_Mig10.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RopeParison.Migrations
+{
+    /// <inheritdoc />
+    public partial class Mig10 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_RopeEditSuggestions_Ropes_RopeId",
+                table: "RopeEditSuggestions");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "RopeId",
+                table: "RopeEditSuggestions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "RopeProperty",
+                table: "RopeEditSuggestions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RopeEditSuggestions_Ropes_RopeId",
+                table: "RopeEditSuggestions",
+                column: "RopeId",
+                principalTable: "Ropes",
+                principalColumn: "RopeId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_RopeEditSuggestions_Ropes_RopeId",
+                table: "RopeEditSuggestions");
+
+            migrationBuilder.DropColumn(
+                name: "RopeProperty",
+                table: "RopeEditSuggestions");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "RopeId",
+                table: "RopeEditSuggestions",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RopeEditSuggestions_Ropes_RopeId",
+                table: "RopeEditSuggestions",
+                column: "RopeId",
+                principalTable: "Ropes",
+                principalColumn: "RopeId");
+        }
+    }
+}

--- a/RopeParison.Data/Model/Rope.cs
+++ b/RopeParison.Data/Model/Rope.cs
@@ -15,8 +15,9 @@ namespace RopeParison.Data.Model
 
         public double Diameter { get; set; }
         public double MassPerUnitLength { get; set; }
-        public double? SheathPercentage { get; set; }
-        
+        public double? SheathPercentage { get; set; } //Nullable. Often not specified.
+
+        //Nullable. Not all ropes have values for all ImpactForce, StaticElong, DynamicElong, DropsBefore options.
         public double? ImpactForce55kgOneStrand { get; set; }
         public double? ImpactForce80kgOneStrand { get; set; }
         public double? ImpactForce80kgTwoStrand { get; set; }
@@ -32,7 +33,7 @@ namespace RopeParison.Data.Model
         public int? DropsBeforeBreak80kgOneStrand { get; set; }
         public int? DropsBeforeBreak80kgTwoStrand { get; set; }
 
-        public double? SheathSlippage { get; set; }
+        public double? SheathSlippage { get; set; } //Nullable. Often not specified.
 
         public virtual RopeCalculatedParameterSet RopeCalculatedParameterSet { get; set; }
 

--- a/RopeParison.Data/Model/RopeEditSuggestion.cs
+++ b/RopeParison.Data/Model/RopeEditSuggestion.cs
@@ -11,6 +11,8 @@ namespace RopeParison.Data.Model
 
         public int RopeId { get; set; }
 
+        public RopeProperty RopeProperty { get; set; } //Indicates which rope property this EditSuggestion is about. Sometimes the EditSuggestion will be to make a value null, which is impossible to identify otherwise!
+
         public string? Name { get; set; }
         public int? BrandId { get; set; }
         public virtual Brand? Brand { get; set; }

--- a/RopeParison.Data/ReadMe.txt
+++ b/RopeParison.Data/ReadMe.txt
@@ -3,3 +3,6 @@ Package Manager Console
 Select "Default project:" RopeParison.Data
 add-migration MigrationName -Context DataContext
 update-database -Context DataContext
+
+Script-Migration -Context DataContext <FromMigration> <ToMigration>
+E.g. <Script-Migration -Context DataContext Mig8 Mig9> would produce a script which applied Mig9.

--- a/RopeParison.Data/Services/RopeDataService.cs
+++ b/RopeParison.Data/Services/RopeDataService.cs
@@ -503,30 +503,35 @@ namespace RopeParison.Data.Services
 
         private void UpdateRope(Rope rope, RopeEditSuggestion rES)
         {
-            if (rES.Name != null) { rope.Name = rES.Name; }
-            if (rES.BrandId != null) { UpdateRopeBrand(rope, rES.BrandId.Value); }
-            if (rES.Category != null) { rope.Category = rES.Category.Value; }
+            if (rES.RopeProperty == RopeProperty.Name) { rope.Name = rES.Name; }
+            else if (rES.RopeProperty == RopeProperty.Brand && rES.BrandId.HasValue) { UpdateRopeBrand(rope, rES.BrandId.Value); }
+            else if (rES.RopeProperty == RopeProperty.Category && rES.Category.HasValue) { rope.Category = rES.Category.Value; }
 
-            if (rES.Diameter != null) { rope.Diameter = rES.Diameter.Value; }
-            if (rES.MassPerUnitLength != null) { rope.MassPerUnitLength = rES.MassPerUnitLength.Value; }
-            if (rES.SheathPercentage != null) { rope.SheathPercentage = rES.SheathPercentage.Value; }
+            else if (rES.RopeProperty == RopeProperty.Diameter && rES.Diameter.HasValue) { rope.Diameter = rES.Diameter.Value; }
+            else if (rES.RopeProperty == RopeProperty.MassPerUnitLength && rES.MassPerUnitLength.HasValue) { rope.MassPerUnitLength = rES.MassPerUnitLength.Value; }
+            else if (rES.RopeProperty == RopeProperty.SheathPercentage) { rope.SheathPercentage = rES.SheathPercentage; }
 
-            if (rES.ImpactForce55kgOneStrand != null) { rope.ImpactForce55kgOneStrand = rES.ImpactForce55kgOneStrand.Value; }
-            if (rES.ImpactForce80kgOneStrand != null) { rope.ImpactForce80kgOneStrand = rES.ImpactForce80kgOneStrand.Value; }
-            if (rES.ImpactForce80kgTwoStrand != null) { rope.ImpactForce80kgTwoStrand = rES.ImpactForce80kgTwoStrand.Value; }
+            else if (rES.RopeProperty == RopeProperty.ImpactForce55kgOneStrand) { rope.ImpactForce55kgOneStrand = rES.ImpactForce55kgOneStrand; }
+            else if (rES.RopeProperty == RopeProperty.ImpactForce80kgOneStrand) { rope.ImpactForce80kgOneStrand = rES.ImpactForce80kgOneStrand; }
+            else if (rES.RopeProperty == RopeProperty.ImpactForce80kgTwoStrand) { rope.ImpactForce80kgTwoStrand = rES.ImpactForce80kgTwoStrand; }
 
-            if (rES.StaticElongation80kgOneStrand != null) { rope.StaticElongation80kgOneStrand = rES.StaticElongation80kgOneStrand.Value; }
-            if (rES.StaticElongation80kgTwoStrand != null) { rope.StaticElongation80kgTwoStrand = rES.StaticElongation80kgTwoStrand.Value; }
+            else if (rES.RopeProperty == RopeProperty.StaticElongation80kgOneStrand) { rope.StaticElongation80kgOneStrand = rES.StaticElongation80kgOneStrand; }
+            else if (rES.RopeProperty == RopeProperty.StaticElongation80kgTwoStrand) { rope.StaticElongation80kgTwoStrand = rES.StaticElongation80kgTwoStrand; }
 
-            if (rES.DynamicElongation55kgOneStrand != null) { rope.DynamicElongation55kgOneStrand = rES.DynamicElongation55kgOneStrand.Value; }
-            if (rES.DynamicElongation80kgOneStrand != null) { rope.DynamicElongation80kgOneStrand = rES.DynamicElongation80kgOneStrand.Value; }
-            if (rES.DynamicElongation80kgTwoStrand != null) { rope.DynamicElongation80kgTwoStrand = rES.DynamicElongation80kgTwoStrand.Value; }
+            else if (rES.RopeProperty == RopeProperty.DynamicElongation55kgOneStrand) { rope.DynamicElongation55kgOneStrand = rES.DynamicElongation55kgOneStrand; }
+            else if (rES.RopeProperty == RopeProperty.DynamicElongation80kgOneStrand) { rope.DynamicElongation80kgOneStrand = rES.DynamicElongation80kgOneStrand; }
+            else if (rES.RopeProperty == RopeProperty.DynamicElongation80kgTwoStrand) { rope.DynamicElongation80kgTwoStrand = rES.DynamicElongation80kgTwoStrand; }
 
-            if (rES.DropsBeforeBreak55kgOneStrand != null) { rope.DropsBeforeBreak55kgOneStrand = rES.DropsBeforeBreak55kgOneStrand.Value; }
-            if (rES.DropsBeforeBreak80kgOneStrand != null) { rope.DropsBeforeBreak80kgOneStrand = rES.DropsBeforeBreak80kgOneStrand.Value; }
-            if (rES.DropsBeforeBreak80kgTwoStrand != null) { rope.DropsBeforeBreak80kgTwoStrand = rES.DropsBeforeBreak80kgTwoStrand.Value; }
+            else if (rES.RopeProperty == RopeProperty.DropsBeforeBreak55kgOneStrand) { rope.DropsBeforeBreak55kgOneStrand = rES.DropsBeforeBreak55kgOneStrand; }
+            else if (rES.RopeProperty == RopeProperty.DropsBeforeBreak80kgOneStrand) { rope.DropsBeforeBreak80kgOneStrand = rES.DropsBeforeBreak80kgOneStrand; }
+            else if (rES.RopeProperty == RopeProperty.DropsBeforeBreak80kgTwoStrand) { rope.DropsBeforeBreak80kgTwoStrand = rES.DropsBeforeBreak80kgTwoStrand; }
 
-            if (rES.SheathSlippage != null) { rope.SheathSlippage = rES.SheathSlippage.Value; }
+            else if (rES.RopeProperty == RopeProperty.SheathSlippage) { rope.SheathSlippage = rES.SheathSlippage; }
+
+            else
+            {
+                throw new Exception($"Error applying RopeEditSuggestion: {rES.RopeEditSuggestionId}, RopeProperty: {rES.RopeProperty}.");
+            }
         }
 
         private void UpdateRopeBrand(Rope rope, int brandId)
@@ -545,6 +550,9 @@ namespace RopeParison.Data.Services
         private void UpdateRopeEditSuggestion(RopeEditSuggestion rES, RopeEditSuggestionDto rESDto)
         {
             rES.RopeEditSuggestionId = rESDto.RopeEditSuggestionId;
+
+            rES.RopeProperty = rESDto.RopeProperty;
+
             rES.Name = rESDto.Name;
             rES.BrandId = rESDto.BrandId;
             rES.Category = rESDto.Category?.ToModel();

--- a/RopeParison.Data/Services/RopeEditSuggestionDataService.cs
+++ b/RopeParison.Data/Services/RopeEditSuggestionDataService.cs
@@ -57,6 +57,8 @@ namespace RopeParison.Data.Services
             //Calculate CalculatedParameterSet
             if (model != null && dto != null)
             {
+                model.RopeProperty = dto.RopeProperty;
+
                 model.Name = dto.Name;
                 model.BrandId = dto.BrandId;
                 //model.Brand = dto.Brand != null ? dto.Brand. : null;
@@ -92,6 +94,8 @@ namespace RopeParison.Data.Services
             if (model != null)
             {
                 dto.RopeEditSuggestionId = model.RopeEditSuggestionId;
+
+                dto.RopeProperty = model.RopeProperty;
 
                 dto.Name = model.Name;
                 dto.BrandId = model.BrandId;

--- a/RopeParison.Logic/Protocol/Validators/RopeDtoValidator.cs
+++ b/RopeParison.Logic/Protocol/Validators/RopeDtoValidator.cs
@@ -33,7 +33,7 @@ namespace RopeParison.Logic.Protocol.Validators
             //RuleFor(p => p.SheathPercentage).NotEmpty().WithMessage(MustBeSpecified("Sheath %"));
             //RuleFor(p => p.SheathPercentage).GreaterThan(0).WithMessage(NotZeroOrLess("Sheath %"));
             //RuleFor(p => p.SheathPercentage).LessThan(100).WithMessage(Not100OrMore("Sheath %"));
-            //Not all ropes specify sheath percentage. Annoying.
+            //Not all ropes specify sheath percentage. Annoying. Not a required field.
 
             RuleFor(p => p.ImpactForce55kgOneStrand).NotEmpty().WithMessage(MustBeSpecified("Impact Force (55kg, One Strand)"))
                 .When(p => p.Has_ImpactForce55kgOneStrand());
@@ -74,7 +74,8 @@ namespace RopeParison.Logic.Protocol.Validators
                 .When(p => p.Has_DynamicElongation80kgTwoStrand());
             RuleFor(p => p.DynamicElongation80kgTwoStrand).GreaterThan(0).WithMessage(NotZeroOrLess("Dynamic Elongation (80kg, Two Strand)"))
                 .When(p => p.Has_DynamicElongation80kgTwoStrand());
-            _ropeService = ropeService;
+
+            //Not all ropes specify sheath slippage. Annoying. Not a required field.
         }
 
         public string MustBeSpecified(string param)

--- a/RopeParison.Logic/Services/RopeService.cs
+++ b/RopeParison.Logic/Services/RopeService.cs
@@ -135,31 +135,34 @@ namespace RopeParison.Logic.Services
             RopeEditSuggestionDto rES = new RopeEditSuggestionDto();
 
             //Strategy is a separate RopeEditSuggestion for each individual change.
+            //This is not the most efficient way of doing things. (More efficent to have a separate list of suggestions for each rope property, but more faff.)
+            //It is easy to maintain.
+            //It is easy to look at the raw db data.
             
-            if (rope.Name != ropeEdit.Name) { rES.Name = ropeEdit.Name; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.Brand.BrandId != ropeEdit.Brand.BrandId) { rES.BrandId = ropeEdit.Brand.BrandId; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.Category != ropeEdit.Category) { rES.Category = ropeEdit.Category; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.Name != ropeEdit.Name) { rES.Name = ropeEdit.Name; rES.RopeProperty = RopeProperty.Name; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.Brand.BrandId != ropeEdit.Brand.BrandId) { rES.BrandId = ropeEdit.Brand.BrandId; rES.RopeProperty = RopeProperty.Brand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.Category != ropeEdit.Category) { rES.Category = ropeEdit.Category; rES.RopeProperty = RopeProperty.Category; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            if (rope.Diameter != ropeEdit.Diameter) { rES.Diameter = ropeEdit.Diameter; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.MassPerUnitLength != ropeEdit.MassPerUnitLength) { rES.MassPerUnitLength = ropeEdit.MassPerUnitLength; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.SheathPercentage != ropeEdit.SheathPercentage) { rES.SheathPercentage = ropeEdit.SheathPercentage; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.Diameter != ropeEdit.Diameter) { rES.Diameter = ropeEdit.Diameter; rES.RopeProperty = RopeProperty.Diameter; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.MassPerUnitLength != ropeEdit.MassPerUnitLength) { rES.MassPerUnitLength = ropeEdit.MassPerUnitLength; rES.RopeProperty = RopeProperty.MassPerUnitLength; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.SheathPercentage != ropeEdit.SheathPercentage) { rES.SheathPercentage = ropeEdit.SheathPercentage; rES.RopeProperty = RopeProperty.SheathPercentage; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            if (rope.ImpactForce55kgOneStrand != ropeEdit.ImpactForce55kgOneStrand) { rES.ImpactForce55kgOneStrand = ropeEdit.ImpactForce55kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.ImpactForce80kgOneStrand != ropeEdit.ImpactForce80kgOneStrand) { rES.ImpactForce80kgOneStrand = ropeEdit.ImpactForce80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.ImpactForce80kgTwoStrand != ropeEdit.ImpactForce80kgTwoStrand) { rES.ImpactForce80kgTwoStrand = ropeEdit.ImpactForce80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.ImpactForce55kgOneStrand != ropeEdit.ImpactForce55kgOneStrand) { rES.ImpactForce55kgOneStrand = ropeEdit.ImpactForce55kgOneStrand; rES.RopeProperty = RopeProperty.ImpactForce55kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.ImpactForce80kgOneStrand != ropeEdit.ImpactForce80kgOneStrand) { rES.ImpactForce80kgOneStrand = ropeEdit.ImpactForce80kgOneStrand; rES.RopeProperty = RopeProperty.ImpactForce80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.ImpactForce80kgTwoStrand != ropeEdit.ImpactForce80kgTwoStrand) { rES.ImpactForce80kgTwoStrand = ropeEdit.ImpactForce80kgTwoStrand; rES.RopeProperty = RopeProperty.ImpactForce80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            if (rope.StaticElongation80kgOneStrand != ropeEdit.StaticElongation80kgOneStrand) { rES.StaticElongation80kgOneStrand = ropeEdit.StaticElongation80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.StaticElongation80kgTwoStrand != ropeEdit.StaticElongation80kgTwoStrand) { rES.StaticElongation80kgTwoStrand = ropeEdit.StaticElongation80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.StaticElongation80kgOneStrand != ropeEdit.StaticElongation80kgOneStrand) { rES.StaticElongation80kgOneStrand = ropeEdit.StaticElongation80kgOneStrand; rES.RopeProperty = RopeProperty.StaticElongation80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.StaticElongation80kgTwoStrand != ropeEdit.StaticElongation80kgTwoStrand) { rES.StaticElongation80kgTwoStrand = ropeEdit.StaticElongation80kgTwoStrand; rES.RopeProperty = RopeProperty.StaticElongation80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            if (rope.DynamicElongation55kgOneStrand != ropeEdit.DynamicElongation55kgOneStrand) { rES.DynamicElongation55kgOneStrand = ropeEdit.DynamicElongation55kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.DynamicElongation80kgOneStrand != ropeEdit.DynamicElongation80kgOneStrand) { rES.DynamicElongation80kgOneStrand = ropeEdit.DynamicElongation80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.DynamicElongation80kgTwoStrand != ropeEdit.DynamicElongation80kgTwoStrand) { rES.DynamicElongation80kgTwoStrand = ropeEdit.DynamicElongation80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.DynamicElongation55kgOneStrand != ropeEdit.DynamicElongation55kgOneStrand) { rES.DynamicElongation55kgOneStrand = ropeEdit.DynamicElongation55kgOneStrand; rES.RopeProperty = RopeProperty.DynamicElongation55kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.DynamicElongation80kgOneStrand != ropeEdit.DynamicElongation80kgOneStrand) { rES.DynamicElongation80kgOneStrand = ropeEdit.DynamicElongation80kgOneStrand; rES.RopeProperty = RopeProperty.DynamicElongation80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.DynamicElongation80kgTwoStrand != ropeEdit.DynamicElongation80kgTwoStrand) { rES.DynamicElongation80kgTwoStrand = ropeEdit.DynamicElongation80kgTwoStrand; rES.RopeProperty = RopeProperty.DynamicElongation80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            if (rope.DropsBeforeBreak55kgOneStrand != ropeEdit.DropsBeforeBreak55kgOneStrand) { rES.DropsBeforeBreak55kgOneStrand = ropeEdit.DropsBeforeBreak55kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.DropsBeforeBreak80kgOneStrand != ropeEdit.DropsBeforeBreak80kgOneStrand) { rES.DropsBeforeBreak80kgOneStrand = ropeEdit.DropsBeforeBreak80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            if (rope.DropsBeforeBreak80kgTwoStrand != ropeEdit.DropsBeforeBreak80kgTwoStrand) { rES.DropsBeforeBreak80kgTwoStrand = ropeEdit.DropsBeforeBreak80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.DropsBeforeBreak55kgOneStrand != ropeEdit.DropsBeforeBreak55kgOneStrand) { rES.DropsBeforeBreak55kgOneStrand = ropeEdit.DropsBeforeBreak55kgOneStrand; rES.RopeProperty = RopeProperty.DropsBeforeBreak55kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.DropsBeforeBreak80kgOneStrand != ropeEdit.DropsBeforeBreak80kgOneStrand) { rES.DropsBeforeBreak80kgOneStrand = ropeEdit.DropsBeforeBreak80kgOneStrand; rES.RopeProperty = RopeProperty.DropsBeforeBreak80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.DropsBeforeBreak80kgTwoStrand != ropeEdit.DropsBeforeBreak80kgTwoStrand) { rES.DropsBeforeBreak80kgTwoStrand = ropeEdit.DropsBeforeBreak80kgTwoStrand; rES.RopeProperty = RopeProperty.DropsBeforeBreak80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            if (rope.SheathSlippage != ropeEdit.SheathSlippage) { rES.SheathSlippage = ropeEdit.SheathSlippage; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
+            if (rope.SheathSlippage != ropeEdit.SheathSlippage) { rES.SheathSlippage = ropeEdit.SheathSlippage; rES.RopeProperty = RopeProperty.SheathSlippage; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
             //_ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES);
         }

--- a/RopeParison.Logic/Services/RopeService.cs
+++ b/RopeParison.Logic/Services/RopeService.cs
@@ -134,51 +134,31 @@ namespace RopeParison.Logic.Services
         {
             RopeEditSuggestionDto rES = new RopeEditSuggestionDto();
 
-            //Strategy is a separate RopeEditSuggestion for each individual change. (Used to be
+            //Strategy is a separate RopeEditSuggestion for each individual change.
             
-            //rES.Name = rope.Name == ropeEdit.Name ? null : ropeEdit.Name;
             if (rope.Name != ropeEdit.Name) { rES.Name = ropeEdit.Name; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.BrandId = rope.Brand.BrandId == ropeEdit.Brand.BrandId ? null : ropeEdit.Brand.BrandId;
             if (rope.Brand.BrandId != ropeEdit.Brand.BrandId) { rES.BrandId = ropeEdit.Brand.BrandId; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.Brand = rope.Brand.BrandId == ropeEdit.Brand.BrandId ? null : ropeEdit.Brand;
-            //if (rope.Brand.BrandId != ropeEdit.Brand.BrandId) { rES.Brand = ropeEdit.Brand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.Category = rope.Category == ropeEdit.Category ? null : ropeEdit.Category;
             if (rope.Category != ropeEdit.Category) { rES.Category = ropeEdit.Category; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            //rES.Diameter = rope.Diameter == ropeEdit.Diameter ? null : ropeEdit.Diameter;
             if (rope.Diameter != ropeEdit.Diameter) { rES.Diameter = ropeEdit.Diameter; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.MassPerUnitLength = rope.MassPerUnitLength == ropeEdit.MassPerUnitLength ? null : ropeEdit.MassPerUnitLength;
             if (rope.MassPerUnitLength != ropeEdit.MassPerUnitLength) { rES.MassPerUnitLength = ropeEdit.MassPerUnitLength; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.SheathPercentage = rope.SheathPercentage == ropeEdit.SheathPercentage ? null : ropeEdit.SheathPercentage;
             if (rope.SheathPercentage != ropeEdit.SheathPercentage) { rES.SheathPercentage = ropeEdit.SheathPercentage; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            //rES.ImpactForce55kgOneStrand = rope.ImpactForce55kgOneStrand == ropeEdit.ImpactForce55kgOneStrand ? null : ropeEdit.ImpactForce55kgOneStrand;
             if (rope.ImpactForce55kgOneStrand != ropeEdit.ImpactForce55kgOneStrand) { rES.ImpactForce55kgOneStrand = ropeEdit.ImpactForce55kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.ImpactForce80kgOneStrand = rope.ImpactForce80kgOneStrand == ropeEdit.ImpactForce80kgOneStrand ? null : ropeEdit.ImpactForce80kgOneStrand;
             if (rope.ImpactForce80kgOneStrand != ropeEdit.ImpactForce80kgOneStrand) { rES.ImpactForce80kgOneStrand = ropeEdit.ImpactForce80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.ImpactForce80kgTwoStrand = rope.ImpactForce80kgTwoStrand == ropeEdit.ImpactForce80kgTwoStrand ? null : ropeEdit.ImpactForce80kgTwoStrand;
             if (rope.ImpactForce80kgTwoStrand != ropeEdit.ImpactForce80kgTwoStrand) { rES.ImpactForce80kgTwoStrand = ropeEdit.ImpactForce80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            //rES.StaticElongation80kgOneStrand = rope.StaticElongation80kgOneStrand == ropeEdit.StaticElongation80kgOneStrand ? null : ropeEdit.StaticElongation80kgOneStrand;
             if (rope.StaticElongation80kgOneStrand != ropeEdit.StaticElongation80kgOneStrand) { rES.StaticElongation80kgOneStrand = ropeEdit.StaticElongation80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.StaticElongation80kgTwoStrand = rope.StaticElongation80kgTwoStrand == ropeEdit.StaticElongation80kgTwoStrand ? null : ropeEdit.StaticElongation80kgTwoStrand;
             if (rope.StaticElongation80kgTwoStrand != ropeEdit.StaticElongation80kgTwoStrand) { rES.StaticElongation80kgTwoStrand = ropeEdit.StaticElongation80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            //rES.DynamicElongation55kgOneStrand = rope.DynamicElongation55kgOneStrand == ropeEdit.DynamicElongation55kgOneStrand ? null : ropeEdit.DynamicElongation55kgOneStrand;
             if (rope.DynamicElongation55kgOneStrand != ropeEdit.DynamicElongation55kgOneStrand) { rES.DynamicElongation55kgOneStrand = ropeEdit.DynamicElongation55kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.DynamicElongation80kgOneStrand = rope.DynamicElongation80kgOneStrand == ropeEdit.DynamicElongation80kgOneStrand ? null : ropeEdit.DynamicElongation80kgOneStrand;
             if (rope.DynamicElongation80kgOneStrand != ropeEdit.DynamicElongation80kgOneStrand) { rES.DynamicElongation80kgOneStrand = ropeEdit.DynamicElongation80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.DynamicElongation80kgTwoStrand = rope.DynamicElongation80kgTwoStrand == ropeEdit.DynamicElongation80kgTwoStrand ? null : ropeEdit.DynamicElongation80kgTwoStrand;
             if (rope.DynamicElongation80kgTwoStrand != ropeEdit.DynamicElongation80kgTwoStrand) { rES.DynamicElongation80kgTwoStrand = ropeEdit.DynamicElongation80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            //rES.DropsBeforeBreak55kgOneStrand = rope.DropsBeforeBreak55kgOneStrand == ropeEdit.DropsBeforeBreak55kgOneStrand ? null : ropeEdit.DropsBeforeBreak55kgOneStrand;
             if (rope.DropsBeforeBreak55kgOneStrand != ropeEdit.DropsBeforeBreak55kgOneStrand) { rES.DropsBeforeBreak55kgOneStrand = ropeEdit.DropsBeforeBreak55kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.DropsBeforeBreak80kgOneStrand = rope.DropsBeforeBreak80kgOneStrand == ropeEdit.DropsBeforeBreak80kgOneStrand ? null : ropeEdit.DropsBeforeBreak80kgOneStrand;
             if (rope.DropsBeforeBreak80kgOneStrand != ropeEdit.DropsBeforeBreak80kgOneStrand) { rES.DropsBeforeBreak80kgOneStrand = ropeEdit.DropsBeforeBreak80kgOneStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
-            //rES.DropsBeforeBreak80kgTwoStrand = rope.DropsBeforeBreak80kgTwoStrand == ropeEdit.DropsBeforeBreak80kgTwoStrand ? null : ropeEdit.DropsBeforeBreak80kgTwoStrand;
             if (rope.DropsBeforeBreak80kgTwoStrand != ropeEdit.DropsBeforeBreak80kgTwoStrand) { rES.DropsBeforeBreak80kgTwoStrand = ropeEdit.DropsBeforeBreak80kgTwoStrand; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
-            //rES.SheathSlippage = rope.SheathSlippage == ropeEdit.SheathSlippage ? null : ropeEdit.SheathSlippage;
             if (rope.SheathSlippage != ropeEdit.SheathSlippage) { rES.SheathSlippage = ropeEdit.SheathSlippage; _ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES); rES = new RopeEditSuggestionDto(); }
 
             //_ropeDataService.AddRopeEditSuggestion(rope.RopeId, rES);

--- a/RopeParison.Protocol/Dtos/RopeEditSuggestionDto.cs
+++ b/RopeParison.Protocol/Dtos/RopeEditSuggestionDto.cs
@@ -5,6 +5,9 @@ namespace RopeParison.Protocol
     public class RopeEditSuggestionDto
     {
         public int RopeEditSuggestionId { get; set; }
+
+        public RopeProperty RopeProperty { get; set; }
+
         public string? Name { get; set; }
         public int? BrandId { get; set; }
         public virtual BrandDto? Brand { get; set; }

--- a/RopeParison.Protocol/Dtos/RopePropertyInformationsDto.cs
+++ b/RopeParison.Protocol/Dtos/RopePropertyInformationsDto.cs
@@ -1,5 +1,6 @@
 ﻿namespace RopeParison.Protocol
 {
+    //This should really be a dictionary with key of RopeProperty Enum. Deal with VisibleColCount separately.
     public class RopePropertyInformationsDto
     {
         public int VisibleColCount { get; set; } = 0;

--- a/RopeParison.Protocol/Enum/RopeProperty.cs
+++ b/RopeParison.Protocol/Enum/RopeProperty.cs
@@ -1,0 +1,33 @@
+﻿using RopeParison.Helpers;
+
+namespace RopeParison.Protocol
+{
+    public enum RopeProperty
+    {
+        Name,
+        Brand,
+        Category,
+        
+        Diameter,
+        MassPerUnitLength,
+        SheathPercentage,
+
+        ImpactForce55kgOneStrand,
+        ImpactForce80kgOneStrand,
+        ImpactForce80kgTwoStrand,
+
+        StaticElongation80kgOneStrand,
+        StaticElongation80kgTwoStrand,
+
+        DynamicElongation55kgOneStrand,
+        DynamicElongation80kgOneStrand,
+        DynamicElongation80kgTwoStrand,
+
+        DropsBeforeBreak55kgOneStrand,
+        DropsBeforeBreak80kgOneStrand,
+        DropsBeforeBreak80kgTwoStrand,
+
+        SheathSlippage
+    }
+
+}

--- a/RopeParison/Pages/RopeAdd.razor
+++ b/RopeParison/Pages/RopeAdd.razor
@@ -121,10 +121,10 @@
         }
         @if (edit || approveEdit)
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.Category != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.Category))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.Category != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.Category))
                 {
                     <RP_RopeEditSuggestion item="@item.Category.DisplayName" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -156,10 +156,10 @@
         }
         @if (edit || approveEdit)
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.Name != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.Name))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.Name != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.Name))
                 {
                     <RP_RopeEditSuggestion item="@item.Name" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -195,10 +195,10 @@
         }
         @if (edit || approveEdit)
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.Brand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.Brand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.Brand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.Brand))
                 {
                     <RP_RopeEditSuggestion item="@item.Brand.Name" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -237,10 +237,10 @@
         }
         @if (edit || approveEdit)
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.Diameter != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.Diameter))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.Diameter != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.Diameter))
                 {
                     <RP_RopeEditSuggestion item="@item.Diameter" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -278,10 +278,10 @@
         }
         @if (edit || approveEdit)
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.MassPerUnitLength != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.MassPerUnitLength))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.MassPerUnitLength != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.MassPerUnitLength))
                 {
                     <RP_RopeEditSuggestion item="@item.MassPerUnitLength" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -319,12 +319,19 @@
         }
         @if (edit || approveEdit)
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.SheathPercentage != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.SheathPercentage))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.SheathPercentage != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.SheathPercentage))
                 {
-                    <RP_RopeEditSuggestion item="@item.SheathPercentage" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
+                    if (item.SheathPercentage == null)
+                    {
+                        <RP_RopeEditSuggestion item="@("Unknown")" approveEdit="approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
+                    }
+                    else
+                    {
+                        <RP_RopeEditSuggestion item="item.SheathPercentage" approveEdit="approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
+                    }
                 }
             }
             <RP_RopePropertySeparator></RP_RopePropertySeparator>
@@ -360,12 +367,19 @@
         }
         @if (edit || approveEdit)
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.SheathSlippage != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.SheathSlippage))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.SheathSlippage != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.SheathSlippage))
                 {
-                    <RP_RopeEditSuggestion item="@item.SheathSlippage" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
+                    if (item.SheathSlippage == null)
+                    {
+                        <RP_RopeEditSuggestion item="@("Unknown")" approveEdit="approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
+                    }
+                    else 
+                    {
+                        <RP_RopeEditSuggestion item="@item.SheathSlippage" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
+                    }
                 }
             }
             <RP_RopePropertySeparator></RP_RopePropertySeparator>
@@ -405,10 +419,10 @@
         }
         @if (!Hide_ImpactForce55kgOneStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.ImpactForce55kgOneStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.ImpactForce55kgOneStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.ImpactForce55kgOneStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.ImpactForce55kgOneStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.ImpactForce55kgOneStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -446,10 +460,10 @@
         }
         @if (!Hide_ImpactForce80kgOneStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.ImpactForce80kgOneStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.ImpactForce80kgOneStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.ImpactForce80kgOneStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.ImpactForce80kgOneStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.ImpactForce80kgOneStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -487,10 +501,10 @@
         }
         @if (!Hide_ImpactForce80kgTwoStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.ImpactForce80kgTwoStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.ImpactForce80kgTwoStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.ImpactForce80kgTwoStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.ImpactForce80kgTwoStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.ImpactForce80kgTwoStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -532,10 +546,10 @@
         }
         @if (!Hide_StaticElongation80kgOneStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.StaticElongation80kgOneStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.StaticElongation80kgOneStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.StaticElongation80kgOneStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.StaticElongation80kgOneStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.StaticElongation80kgOneStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -573,10 +587,10 @@
         }
         @if (!Hide_StaticElongation80kgTwoStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.StaticElongation80kgTwoStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.StaticElongation80kgTwoStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.StaticElongation80kgTwoStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.StaticElongation80kgTwoStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.StaticElongation80kgTwoStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -621,10 +635,10 @@
         }
         @if (Show_DynamicElongation55kgOneStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.DynamicElongation55kgOneStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.DynamicElongation55kgOneStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.DynamicElongation55kgOneStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.DynamicElongation55kgOneStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.DynamicElongation55kgOneStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -665,10 +679,10 @@
         }
         @if (Show_DynamicElongation80kgOneStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.DynamicElongation80kgOneStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.DynamicElongation80kgOneStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.DynamicElongation80kgOneStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.DynamicElongation80kgOneStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.DynamicElongation80kgOneStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -709,10 +723,10 @@
         }
         @if (Show_DynamicElongation80kgTwoStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.DynamicElongation80kgTwoStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.DynamicElongation80kgTwoStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.DynamicElongation80kgTwoStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.DynamicElongation80kgTwoStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.DynamicElongation80kgTwoStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -756,10 +770,10 @@
         }
         @if (!Hide_DropsBeforeBreak55kgOneStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.DropsBeforeBreak55kgOneStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.DropsBeforeBreak55kgOneStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.DropsBeforeBreak55kgOneStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.DropsBeforeBreak55kgOneStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.DropsBeforeBreak55kgOneStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -799,10 +813,10 @@
         }
         @if (!Hide_DropsBeforeBreak80kgOneStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.DropsBeforeBreak80kgOneStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.DropsBeforeBreak80kgOneStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.DropsBeforeBreak80kgOneStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.DropsBeforeBreak80kgOneStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.DropsBeforeBreak80kgOneStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -842,10 +856,10 @@
         }
         @if (!Hide_DropsBeforeBreak80kgTwoStrand() && (edit || approveEdit))
         {
-            @if (rope.RopeEditSuggestions.Any(x => x.DropsBeforeBreak80kgTwoStrand != null))
+            @if (rope.RopeEditSuggestions.Any(x => x.RopeProperty == RopeProperty.DropsBeforeBreak80kgTwoStrand))
             {
                 <RP_AlreadyProposedEdits edit="@edit"></RP_AlreadyProposedEdits>
-                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.DropsBeforeBreak80kgTwoStrand != null))
+                @foreach (var item in rope.RopeEditSuggestions.Where(x => x.RopeProperty == RopeProperty.DropsBeforeBreak80kgTwoStrand))
                 {
                     <RP_RopeEditSuggestion item="@item.DropsBeforeBreak80kgTwoStrand" approveEdit="@approveEdit" ApproveEditSuggestion="() => ApproveEditSuggestion(item.RopeEditSuggestionId)" DeleteEditSuggestion="() => DeleteEditSuggestion(item.RopeEditSuggestionId)"></RP_RopeEditSuggestion>
                 }
@@ -853,6 +867,8 @@
             <RP_RopePropertySeparator></RP_RopePropertySeparator>
         }
         <!-- ######################### -->
+
+        <!-- --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- -->
 
         @if (add && IsHalf())
         {


### PR DESCRIPTION
An update to the rope edit suggestions lifecycle. Previously it was impossible to successfully complete the lifecycle to set a nullable rope property to null.

RopeEditSuggestion has RopeProperty added. This indicates which rope property the RES is about.